### PR TITLE
fixing groupNotAllowFilter

### DIFF
--- a/src/pipeline/group.ts
+++ b/src/pipeline/group.ts
@@ -165,67 +165,6 @@ export function buildGroupDenyTest(request: string, groups: Array<Group>, names:
 }
 
 export function buildGroupNotAllowFilter(groups: Array<Group>, groupIds: Array<string>): (req: express.Request, res: express.Response) => boolean {
-    const body = `return ${buildGroupNotAllowTest('req', groups, groupIds)};`;
+    const body = `return !(${buildGroupAllowTest('req', groups, groupIds)});`;
     return createFunction({ mm: mm }, 'req', 'res', body) as (req: express.Request, res: express.Response) => boolean;
-}
-
-export function buildGroupNotAllowTest(request: string, groups: Array<Group>, names: Array<string>) {
-    const func = new Array<string>();
-    const filtered = filter(groups, names);
-
-    filtered.forEach((group, index) => {
-        if (index > 0) {
-            func.push(`||`);
-        }
-        func.push(`(`);
-        group.member.forEach((member, memberIndex) => {
-            if (memberIndex > 0) {
-                func.push(`&&`);
-            }
-            func.push(`(`);
-            let hasMethodFilter = false;
-            if (member.method && member.method.length > 0) {
-                func.push(`(`);
-                hasMethodFilter = true;
-                member.method.forEach((method, i) => {
-                    if (i > 0) {
-                        func.push(`&&`);
-                    }
-                    func.push(`(${request}.method !== '${method.toUpperCase()}')`);
-                });
-                func.push(`)`);
-            }
-            let hasProtocolFilter = false;
-            if (member.protocol && member.protocol.length > 0) {
-                if (hasMethodFilter) {
-                    func.push(`||`);
-                }
-                func.push(`(`);
-                hasProtocolFilter = true;
-                member.protocol.forEach((protocol, i) => {
-                    if (i > 0) {
-                        func.push(`&&`);
-                    }
-                    func.push(`(${request}.protocol !== '${protocol.toLowerCase()}')`);
-                });
-                func.push(`)`);
-            }
-            if (member.path && member.path.length > 0) {
-                if (hasMethodFilter || hasProtocolFilter) {
-                    func.push(`||`);
-                }
-                func.push(`(`);
-                member.path.forEach((path, mIndex) => {
-                    if (mIndex > 0) {
-                        func.push(`&&`);
-                    }
-                    func.push(`!(mm.isMatch(${request}.path, '${normalizePath(path)}'))`);
-                });
-                func.push(`)`);
-            }
-            func.push(`)`);
-        });
-        func.push(`)`);
-    });
-    return func.join('');
 }


### PR DESCRIPTION
There is a bug with response interceptor group property.
If you don't specify group, it all works, response interceptor used everywhere.
If you specify a single group, it still works, response interceptor used for that single group.
If you specify multiple groups, it doesn't work response interceptor never called.

The bug lies at the buildGroupNotAllowTest function, it has bad logic for this purpose.
Noticed that that is only used for response interceptors, so fixed with negating the actual buildGroupAllowTest function and removed the redundant code.