### PR TITLE
Docker compose to use internal link name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  gw:
+    image: treegateway/tree-gateway:latest
+    ports:
+      - '8000:8000'
+      - '8001:8001'
+    links:
+      - 'redis:redis'
+  redis:
+    image: redis:3.2.8-alpine
+    ports:
+      - '6379:6379'

--- a/tree-gateway.json
+++ b/tree-gateway.json
@@ -3,8 +3,8 @@
     "database": {
         "redis": {
             "standalone": {
-                "host": "{REDIS_PORT_6379_TCP_ADDR}",
-                "port": "{REDIS_PORT_6379_TCP_PORT}"
+                "host": "redis",
+                "port": "6379"
             }
         }
     }


### PR DESCRIPTION
With newest docker-compose it does not create environment variables.

Using name which is mentioned in links option, works.